### PR TITLE
Correct check-snapshots & handle paths with spaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.9
 
       - name: Install Dependencies
         shell: bash

--- a/test/check-snapshots
+++ b/test/check-snapshots
@@ -19,7 +19,7 @@ for compiler_flag, extension in checks:
     snapshot_path = test_file + extension
 
     try:
-        output = subprocess.check_output(sys.argv[1:] + [compiler_flag])
+        output = subprocess.check_output(sys.argv[1:] + [compiler_flag], text=True)
     except subprocess.CalledProcessError as error:
         print(error.output)
         sys.exit(error.returncode)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -17,8 +17,8 @@ config.test_format = lit.formats.ShTest()
 config.suffixes = [".cx"]
 config.excludes = ["inputs"]
 config.test_source_root = os.path.dirname(__file__)
-config.substitutions.append(("%cx", cx_path))
-config.substitutions.append(("%FileCheck", lit_config.params.get("filecheck_path") + " -implicit-check-not error:"))
+config.substitutions.append(("%cx", '"' + cx_path + '"'))
+config.substitutions.append(("%FileCheck", '"' + lit_config.params.get("filecheck_path") + "\" -implicit-check-not error:"))
 config.substitutions.append(("check_exit_status", "python '" + helper_scripts_path + "/check_exit_status'"))
 config.substitutions.append(("check-snapshots", "python '" + helper_scripts_path + "/check-snapshots' '" + cx_path + "' '%s'"))
 config.substitutions.append(("%not", "python '" + helper_scripts_path + "/not'"))


### PR DESCRIPTION
When I went to run the tests, my console was flooded with Python stack traces during the snapshot tests from an error stating that `unified_diff` expects strings. It turns out that the (new?) default behaviour of `subprocess.check_output` is to return a `bytes` object instead of a string. Then, even if the contents were equal, the objects would always be different when compared, which would then lead to the bad `unified_diff` call.

I also added a fix for executing tests from a build folder that contains spaces. I'm not sure if it would be better to fix this on the command itself (in the CMake script), or just handle it in the LIT configuration.

As a side note, I noticed the GitHub workflow file sets up Python 2.7. Shouldn't it be bumped up to Python 3? (I was running the tests using Python 3.10 btw)