### PR TITLE
Allow separators in integer literals

### DIFF
--- a/src/ast/token.h
+++ b/src/ast/token.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 #pragma warning(push, 0)
 #include <llvm/ADT/StringRef.h>
@@ -112,9 +113,10 @@ struct Token {
 
     Token() = default;
     Token(Token::Kind kind, SourceLocation location, llvm::StringRef string = {});
+    Token(SourceLocation location, uint64_t val);
     Token::Kind getKind() const { return kind; }
     operator Token::Kind() const { return kind; }
-    llvm::StringRef getString() const { return string; }
+    llvm::StringRef getString() const { return src.string; }
     SourceLocation getLocation() const { return location; }
     bool is(Token::Kind kind) const { return this->kind == kind; }
     bool is(llvm::ArrayRef<Token::Kind> kinds) const;
@@ -123,7 +125,10 @@ struct Token {
 
 private:
     Token::Kind kind;
-    llvm::StringRef string; ///< The substring in the source code representing this token.
+    union {
+        llvm::StringRef string; ///< The substring in the source code representing this token.
+        uint64_t integer; ///< The parsed integer literal value (only valid if this is a IntegerLiteral token)
+    } src;
     SourceLocation location;
 };
 

--- a/src/ast/token.h
+++ b/src/ast/token.h
@@ -111,7 +111,6 @@ struct Token {
         TokenCount
     };
 
-    Token() = default;
     Token(Token::Kind kind, SourceLocation location, llvm::StringRef string = {});
     Token(SourceLocation location, uint64_t val);
     Token::Kind getKind() const { return kind; }

--- a/test/parser/integer-literal-only-separator.cx
+++ b/test/parser/integer-literal-only-separator.cx
@@ -1,0 +1,4 @@
+// RUN: %not %cx -parse %s | %FileCheck %s
+
+// CHECK: [[@LINE+1]]:9: error: hex literal must have at least one digit after '0x'
+var i = 0x__;

--- a/test/parser/integer-literal-separator.cx
+++ b/test/parser/integer-literal-separator.cx
@@ -1,0 +1,6 @@
+// RUN: %cx -parse %s
+
+var a = 1_000__000_;
+var b = 0x_ff_ab30__;
+var c = 0b_10_11__;
+var d = 0o_54_23__;

--- a/test/parser/unexpected-character-after-zero.cx
+++ b/test/parser/unexpected-character-after-zero.cx
@@ -2,5 +2,5 @@
 
 void main() {
     // CHECK: [[@LINE+1]]:14: error: expected newline or ';', got identifier
-    var i = 0_;
+    var i = 0a;
 }


### PR DESCRIPTION
With these changes, you can now write integer literals with separators:
```js
// The underscore can be placed between digits as a separator; this is the integer value 1234567
var a = 1_234_567;
// Works with other bases as well
var b = 0xff_ee;
var c = 0o7_6_7;
var d = 0b10_11;
// Underscores can be joined to make a larger gap between digits
var n = 123__456;
// Separators can be right after the prefix and at the end of the literal as well (is this desirable though?)
var x = 0x_ab;
var y = 42_;
// Won't compile: you still need digits if you're using a prefix!
var z = 0x_;
```
These rules were based off fiddling around with the Rust compiler and seeing what it would accept in its integer literals. Admittedly, the fact that some of the above cases are valid is a bit weird, notably trailing separators and separators immediately after the prefix (and actually, this made `unexpected-character-after-zero.cx` pass by accident, so that had to be adjusted).

I thought of using a single quote `'` like in C++, but it seemed nicer to have an underscore which could be repeated to increase separation between digits without taking up too much noticeable space.

This new syntax is refused on floating-point literals because I wrote all the string-to-integer conversion logic inside the lexer directly in order to determine which characters are part of the final value, and parsing floating-point values is, well... a little too complicated right now.